### PR TITLE
Edit regex to match french grading

### DIFF
--- a/src/climbing-grade.ts
+++ b/src/climbing-grade.ts
@@ -94,8 +94,7 @@ export const gradeSystems = createGradeSystems({
       "9c",
     ],
     regexes: [
-      /^[1-9][abc][+]?$/, // Base french system
-      /^[1-9]([abc][+])?$/, // French where we do not expect letters or plus
+      /^(([2-4])|([5-9][abcABC]))([+]?)?$/,
     ],
     displayName: "French",
   },


### PR DESCRIPTION
Before: Old regex finds match for `2a+` and not `5A`

Now: Check if the str either starts with [2-4] or [5-9][abcABC] and can optional end with [+]